### PR TITLE
Show full log info for peek alias

### DIFF
--- a/git-sh-aliases.bash
+++ b/git-sh-aliases.bash
@@ -31,7 +31,7 @@ gitalias n='git commit --verbose --amend'
 gitalias k='git cherry-pick'
 gitalias re='git rebase --interactive'
 gitalias pop='git reset --soft HEAD^'
-gitalias peek='git log -p --max-count=1'
+gitalias peek='git log --patch --format=full --max-count=1'
 
 # git fetch
 gitalias f='git fetch'


### PR DESCRIPTION
As long as the user is only viewing one commit, it's best to show the full commit info.
