### PR TITLE
WIP: Set terminal title

### DIFF
--- a/git-sh.bash
+++ b/git-sh.bash
@@ -183,7 +183,7 @@ _git_import_aliases () {
 
 # PROMPT =======================================================================
 
-PS1='`_git_headname``_git_upstream_state`!`_git_repo_state``_git_workdir``_git_dirty``_git_dirty_stash`> '
+PS1='\[\e]0;git-sh:$(basename $PWD)\a\]`_git_headname``_git_upstream_state`!`_git_repo_state``_git_workdir``_git_dirty``_git_dirty_stash`> '
 
 ANSI_RESET="\001$(git config --get-color "" "reset")\002"
 


### PR DESCRIPTION
This is a "works for me" version that sets the terminal title to gitsh:<basename>. This is useful e.g. for Guake and xterm to allow distinguishing "regular" and git-sh windows. There's potential for improvement:
- [x] Only do this for xterm
- [x] Different formatting

Let me know if you're interested.
